### PR TITLE
[DEV12] Correction bug d'encodage base64 sur les caractères spéciaux …

### DIFF
--- a/src/app/public/_services/basic-authentication.service.ts
+++ b/src/app/public/_services/basic-authentication.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders, HttpResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { Observable, take } from "rxjs";
+import { Observable } from "rxjs";
 import { environment } from "src/environments/environment";
 import { Buffer } from "buffer";
 import { CredentialsAuthentication } from "../_models/credentials-authentication.model";
@@ -11,7 +11,9 @@ export class BasicAuthenticationService {
   constructor(private http: HttpClient) { }
 
   authenticate(credentials: CredentialsAuthentication): Observable<HttpResponse<any>> {
+    console.log(credentials);
     const encodedCredentials = this.b64Encoder(credentials.username + ':' + credentials.password);
+    console.log(encodedCredentials);
     const httpHeaders= new HttpHeaders().append('Authorization', 'Basic ' + encodedCredentials);
     return this.http.post(
       environment.apiRootUrl + '/auth/authenticate', 
@@ -21,6 +23,6 @@ export class BasicAuthenticationService {
   }
 
   b64Encoder(stringToEncode: string): string {
-    return Buffer.from(stringToEncode, 'binary').toString('base64');
+    return Buffer.from(stringToEncode).toString('base64');
   }
 } 


### PR DESCRIPTION
**Correction du bug suivant :**

Lors de l'encodage en base64 du `username:password`, avant l'envoie de la requête d'authentification, suppression des caractères spéciaux.

**Exemple :** 
Dayïve:aaaaaa _**ENCODAGE**_ RGF5dmU6YWFhYWFh  _**DÉCODAGE**_  Dayve:aaaaaa